### PR TITLE
Set default workflow token permissions to read-only

### DIFF
--- a/.github/workflows/images-to-google-cloud-storage.yml
+++ b/.github/workflows/images-to-google-cloud-storage.yml
@@ -7,6 +7,9 @@ on:
       - images-to-google-cloud-storage/**
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: static analysis

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request applies the OSSF Scorecard **Token-Permissions** remedy.

It sets the default workflow token to read-only by adding a top-level `permissions` block to workflows that lacked one:

- `.github/workflows/images-to-google-cloud-storage.yml`
- `.github/workflows/lint.yml`

Any job that needs more than read access must be granted those permissions at the job level, otherwise it may fail.

See the [OSSF Scorecard guidance](https://github.com/AxisCommunications/github-governance/blob/main/ossf-scorecard/README.md#token-permissions) for details.