### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/images-to-google-cloud-storage.yml
+++ b/.github/workflows/images-to-google-cloud-storage.yml
@@ -15,7 +15,7 @@ jobs:
       run:
         working-directory: images-to-google-cloud-storage
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - run: shellcheck ./create-cloud-resources.sh
       - run: shellcheck ./delete-cloud-resources.sh
       - run: npx @redocly/openapi-cli lint openapi.yaml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
-      - uses: github/super-linter/slim@v5
+      - uses: github/super-linter/slim@45fc0d88288beee4701c62761281edfee85655d7 # v5.0.0
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request applies the OSSF Scorecard **Pinned-Dependencies** remedy.

It pins the GitHub Actions used in the following workflows to full commit SHAs, keeping the original version as a trailing comment:

- `.github/workflows/images-to-google-cloud-storage.yml`
- `.github/workflows/lint.yml`

Renovate recognises the `@<sha> # <version>` format and will keep these pinned actions updated automatically.

See the [OSSF Scorecard guidance](https://github.com/AxisCommunications/github-governance/blob/main/ossf-scorecard/README.md#pinned-dependencies) for details.